### PR TITLE
Updated sf-ios to 5.0.0 to use NS_ENUM for Swift interoperability

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Install
       run: pod install
     - name: Build & Test
-      run: xcodebuild test -workspace grid-ios.xcworkspace -scheme grid-ios -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14'
+      run: xcodebuild test -workspace grid-ios.xcworkspace -scheme grid-ios -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Install
       run: pod install
     - name: Build
-      run: xcodebuild build-for-testing -workspace grid-ios.xcworkspace -scheme grid-ios -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14'
+      run: xcodebuild build-for-testing -workspace grid-ios.xcworkspace -scheme grid-ios -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
-# 1.0.8 (TBD)
+# 2.0.0
 
-* TBD
+* sf-ios 5.0.0 (Breaking change for NS_ENUM symbol exposure to Swift)
 
 ## [1.0.7](https://github.com/ngageoint/grid-ios/releases/tag/1.0.7) (04-08-2024)
 

--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,12 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '12.0'
+platform :ios, '15.0'
 use_frameworks!
 
 target 'grid-ios' do
   pod 'color-ios', '~> 1.0.2'
-  pod 'sf-ios', '~> 4.1.4'
+#  pod 'sf-ios', '5.0.0'
+  pod 'sf-ios', :git => 'https://github.com/ngageoint/simple-features-ios.git', :branch => 'psolt/v5-NS_ENUM'
+
 
   target 'grid-iosTests' do
     inherit! :complete

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Open grid-ios.xcworkspace in Xcode or build from command line:
 
 Run tests from Xcode or from command line:
 
-    xcodebuild test -workspace 'grid-ios.xcworkspace' -scheme grid-ios -destination 'platform=iOS Simulator,name=iPhone 15'
+    xcodebuild test -workspace 'grid-ios.xcworkspace' -scheme grid-ios -destination 'platform=iOS Simulator,name=iPhone 16'
 
 ### Include Library ###
 
@@ -55,12 +55,12 @@ Include this repository by specifying it in a Podfile using a supported option.
 
 Pull from [CocoaPods](https://cocoapods.org/pods/grid-ios):
 
-    pod 'grid-ios', '~> 1.0.7'
+    pod 'grid-ios', '~> 2.0.0'
 
 Pull from GitHub:
 
     pod 'grid-ios', :git => 'https://github.com/ngageoint/grid-ios.git', :branch => 'master'
-    pod 'grid-ios', :git => 'https://github.com/ngageoint/grid-ios.git', :tag => '1.0.7'
+    pod 'grid-ios', :git => 'https://github.com/ngageoint/grid-ios.git', :tag => '2.0.0'
 
 Include as local project:
 

--- a/grid-ios.podspec
+++ b/grid-ios.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.requires_arc     = true
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
-  s.platform         = :ios, '12.0'
-  s.ios.deployment_target = '12.0'
+  s.platform         = :ios, '15.0'
+  s.ios.deployment_target = '15.0'
 
   s.source_files = 'grid-ios/**/*.swift'
 

--- a/grid-ios.podspec
+++ b/grid-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'grid-ios'
-  s.version          = '1.0.8'
+  s.version          = '2.0.0'
   s.license          =  {:type => 'MIT', :file => 'LICENSE' }
   s.summary          = 'iOS SDK for Grids'
   s.homepage         = 'https://github.com/ngageoint/grid-ios'
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
 
   s.dependency 'color-ios', '~> 1.0.2'
-  s.dependency 'sf-ios', '~> 4.1.4'
+  s.dependency 'sf-ios', '5.0.0'
 end

--- a/grid-ios.xcodeproj/project.pbxproj
+++ b/grid-ios.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					04281FEC2899BD7F00026382 = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -433,6 +433,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -496,6 +497,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -554,6 +556,7 @@
 			baseConfigurationReference = E851D60405F0F6192D5968E0 /* Pods-grid-ios.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -561,6 +564,8 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -570,6 +575,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = mil.nga.grid;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -587,6 +593,7 @@
 			baseConfigurationReference = 3295100FC695C71079321C28 /* Pods-grid-ios.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -594,6 +601,8 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -603,6 +612,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = mil.nga.grid;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -618,7 +628,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 43F6D866DB2D2299E81BE1D4 /* Pods-grid-ios-grid-iosTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -635,7 +644,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4E9E5249E3C73D594F06BCAF /* Pods-grid-ios-grid-iosTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/grid-ios.xcodeproj/xcshareddata/xcschemes/grid-ios.xcscheme
+++ b/grid-ios.xcodeproj/xcshareddata/xcschemes/grid-ios.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/grid-ios/features/Line.swift
+++ b/grid-ios/features/Line.swift
@@ -55,7 +55,7 @@ open class Line: SFLine {
      *            second point
      */
     public init(_ point1: GridPoint, _ point2: GridPoint) {
-        super.init(type:SF_LINESTRING, andHasZ: false, andHasM: false)
+        super.init(type:.LINESTRING, andHasZ: false, andHasM: false)
         setPoints(point1, point2)
     }
     
@@ -66,7 +66,7 @@ open class Line: SFLine {
      *            line to copy
      */
     public init(_ line: Line) {
-        super.init(type:SF_LINESTRING, andHasZ: line.hasZ, andHasM: line.hasM)
+        super.init(type:.LINESTRING, andHasZ: line.hasZ, andHasM: line.hasM)
         setPoints(line.point1, line.point2)
     }
     


### PR DESCRIPTION
* Updated sf-ios to 5.0.0 to use NS_ENUM for Swift interoperability